### PR TITLE
fix subword merging in tokenizer

### DIFF
--- a/core_nn/tokenization/utils.py
+++ b/core_nn/tokenization/utils.py
@@ -186,7 +186,10 @@ class TokenizerUtils:
         current_word = ""
         
         for token in tokens:
-            if token.endswith("@@"):
+            if token.startswith("@@") and token.endswith("@@"):
+                # Middle piece of a word
+                current_word += token[2:-2]
+            elif token.endswith("@@"):
                 # Start or continue a word
                 current_word += token[:-2]
             elif token.startswith("@@"):
@@ -196,11 +199,13 @@ class TokenizerUtils:
                     merged.append(current_word)
                     current_word = ""
             else:
-                # Complete token
+                # Final piece of a split word or a standalone token
                 if current_word:
+                    current_word += token
                     merged.append(current_word)
                     current_word = ""
-                merged.append(token)
+                else:
+                    merged.append(token)
         
         # Handle any remaining partial word
         if current_word:

--- a/tests/test_asc_tokenizer.py
+++ b/tests/test_asc_tokenizer.py
@@ -7,8 +7,8 @@ import tempfile
 from pathlib import Path
 
 from core_nn.tokenization import (
-    ASCTokenizer, ASCConfig, TokenizerFactory, 
-    create_tokenizer_from_config, SimpleTokenizer
+    ASCTokenizer, ASCConfig, TokenizerFactory,
+    create_tokenizer_from_config, SimpleTokenizer, TokenizerUtils
 )
 from core_nn.config.schema import TokenizerConfig
 
@@ -197,6 +197,14 @@ class TestASCTokenizer:
 
         assert token_ids1 == token_ids2
         assert cache_hits > 0
+
+    def test_merge_subword_tokens_handles_suffixes(self):
+        """Ensure subword tokens merge across boundaries."""
+        tokens = ["token@@", "izer"]
+        assert TokenizerUtils.merge_subword_tokens(tokens) == ["tokenizer"]
+
+        tokens = ["multi@@", "@@part@@", "token"]
+        assert TokenizerUtils.merge_subword_tokens(tokens) == ["multiparttoken"]
     
     def test_statistics(self, tokenizer):
         """Test tokenizer statistics."""


### PR DESCRIPTION
## Summary
- fix `merge_subword_tokens` to handle trailing and middle subword pieces correctly
- test subword merging across boundaries

## Testing
- `pytest tests/test_asc_tokenizer.py::TestASCTokenizer::test_merge_subword_tokens_handles_suffixes -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d6f87bed8832db9cf4b4802b777a7