### PR TITLE
docs: fix repository path in getting started guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -7,7 +7,7 @@
 1. **Clone the repository:**
 ```bash
 git clone https://github.com/paredezadrian/core_nn.git
-cd core-nn
+cd core_nn
 ```
 
 2. **Install dependencies:**


### PR DESCRIPTION
## Summary
- fix repository folder name in getting started guide

## Testing
- `pip install zstandard`
- `PYTHONPATH=$PWD pytest tests/test_kpack.py::TestCapsuleMetadata::test_default_metadata -q`


------
https://chatgpt.com/codex/tasks/task_e_688d716747b0832d8dada0bc3803965e