### PR TITLE
Use BytesIO for module offloading serialization

### DIFF
--- a/core_nn/components/execution_engine.py
+++ b/core_nn/components/execution_engine.py
@@ -11,6 +11,7 @@ import asyncio
 import threading
 import queue
 import time
+import io
 import psutil
 from typing import Dict, List, Tuple, Optional, Any, Callable, Union
 from dataclasses import dataclass
@@ -124,7 +125,9 @@ class ModuleManager:
         try:
             # Serialize module
             module = self.modules[module_id]
-            serialized = torch.save(module.state_dict(), None)
+            buffer = io.BytesIO()
+            torch.save(module.state_dict(), buffer)
+            serialized = buffer.getvalue()
             
             # Store serialized version
             self.offloaded_modules[module_id] = serialized


### PR DESCRIPTION
## Summary
- Serialize module state to an in-memory `io.BytesIO` buffer instead of using `torch.save(..., None)`.
- Import the `io` module to support buffer usage.

## Testing
- `PYTHONPATH=. pytest tests/test_core_components.py -q` *(fails: ModuleNotFoundError: No module named 'zstandard')*

------
https://chatgpt.com/codex/tasks/task_e_688d71e5cf88832dac7f66582f52e9aa