### PR TITLE
docs: clarify auto-detected device in get_device_info

### DIFF
--- a/core_nn/utils/device.py
+++ b/core_nn/utils/device.py
@@ -47,10 +47,11 @@ def get_optimal_device(preferred: str = "auto") -> torch.device:
 def get_device_info(device: Optional[torch.device] = None) -> Dict[str, Any]:
     """
     Get detailed device information.
-    
+
     Args:
-        device: Device to get info for (default: current device)
-        
+        device: Device to get info for. If ``None``, an optimal device is
+            auto-detected via ``get_optimal_device()``.
+
     Returns:
         Dictionary with device information
     """


### PR DESCRIPTION
## Summary
- clarify that `get_device_info` auto-detects the optimal device when none is provided

## Testing
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_688d71e71270832d802b159d87259653